### PR TITLE
Prepare discord-rpc 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os:
   - linux
-  - osx
+  - darwin
 language: java
 sudo: false
 script: mvn clean verify

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ For further information regarding joining, spectating and getting greenlit, plea
 
 ## The Example Application
 Contained in this repository is a .JAR file called ``RPCTest.jar``. This simple command line application can be used to test the Rich Presence
-for yourself! Simply add the Application named "Derp" to your Discord Games, and it will be recognized. Since Discord only detects games that have an active window, I discourage you to close the small window called "Derp" that will pop up as soon as you start the RPCTest.
+for yourself! Simply add the Application named "Derp" to your Discord Games, and it will be recognized. Since Discord only detects games that have an active window, I discourage you from closing the small window called "Derp" that will pop up as soon as you start the RPCTest.
 
 The RPCTest has only two commands:
   - ``test`` will increase the "score" value in the details of your presence.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-![Logo](https://github.com/vatuu/discord-rpc/raw/master/rpc.png "Java Discord RPC")
+<img src="https://raw.githubusercontent.com/vatuu/discord-rpc/master/rpc.png" align="right" height="256" width="256"/>
 
 [![jitpack](https://jitpack.io/v/Vatuu/discord-rpc.svg)](https://jitpack.io/#Vatuu/discord-rpc) [![Build Status](https://travis-ci.org/Vatuu/discord-rpc.svg?branch=master)](https://travis-ci.org/Vatuu/discord-rpc) 
-
 
 # discord-rpc
 Java Wrapper of the Discord-RPC Library for Discord Rich Presence.

--- a/RPCTest/pom.xml
+++ b/RPCTest/pom.xml
@@ -39,6 +39,28 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>lib/</classpathPrefix>
+                            <mainClass>net.arikia.dev.drpctest.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.arikia.dev</groupId>
+            <artifactId>discord-rpc</artifactId>
+            <version>LATEST</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/RPCTest/src/main/java/net/arikia/dev/drpctest/Main.java
+++ b/RPCTest/src/main/java/net/arikia/dev/drpctest/Main.java
@@ -1,3 +1,5 @@
+package net.arikia.dev.drpctest;
+
 import net.arikia.dev.drpc.DiscordEventHandlers;
 import net.arikia.dev.drpc.DiscordRPC;
 import net.arikia.dev.drpc.DiscordRichPresence;
@@ -17,8 +19,6 @@ public class Main{
         boolean running = true;
 
         int score = 0;
-
-        System.out.println(System.getProperty("sun.arch.data.model").equals("64"));
 
         initDiscord();
 

--- a/RPCTest/src/main/java/net/arikia/dev/drpctest/Main.java
+++ b/RPCTest/src/main/java/net/arikia/dev/drpctest/Main.java
@@ -3,82 +3,61 @@ package net.arikia.dev.drpctest;
 import net.arikia.dev.drpc.DiscordEventHandlers;
 import net.arikia.dev.drpc.DiscordRPC;
 import net.arikia.dev.drpc.DiscordRichPresence;
-import net.arikia.dev.drpc.callbacks.ReadyCallback;
 
 import javax.swing.*;
 import java.util.Scanner;
 
-public class Main{
+public class Main {
 
-    public static boolean ready = false;
-
-    public static void main(String[] args){
-
-        Window w = new Window();
-
-        boolean running = true;
-
-        int score = 0;
+    public static void main(String[] args) {
 
         initDiscord();
 
-        while(running){
+        JFrame frame = new JFrame("Derp");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        JLabel text = new JLabel("In Discord, set your active game to: \"Derp\"");
+        frame.getContentPane().add(text, SwingConstants.CENTER);
+        frame.setResizable(false);
+        frame.pack();
+        frame.setVisible(true);
+
+        int score = 0;
+
+        while (true) {
+            System.out.println("discordRunCallbacks...");
             DiscordRPC.discordRunCallbacks();
+            System.out.println("discordRunCallbacks - Success");
 
-            if(!ready)
-                continue;
+            System.out.println("getInput...");
+            System.out.print("> ");
+            Scanner in = new Scanner(System.in);
+            String input = in.nextLine();
+            System.out.println("getInput - Success");
 
-            String input = getInput();
-
-            if(input.equalsIgnoreCase("test")){
-                System.out.println("Test.");
-                score++;
-            }else if(input.equals("shutdown")){
-                running = false;
-            }else{
-                System.out.println("Unknown Command.");
+            if (!input.equalsIgnoreCase("shutdown")) {
+                if (input.equalsIgnoreCase("test")) {
+                    System.out.println("Test.");
+                    score++;
+                    DiscordRichPresence rich = new DiscordRichPresence();
+                    rich.state = "Running Test | Private";
+                    rich.details = "Score = " + score;
+                    DiscordRPC.discordUpdatePresence(rich);
+                } else {
+                    System.out.println("Unknown Command!");
+                }
+            } else {
+                // lol.
+                DiscordRPC.discordShutdown();
+                frame.dispose();
+                System.exit(0);
             }
-            DiscordRichPresence rich = new DiscordRichPresence();
-            rich.state = "Running Test | Private";
-            rich.details = "Score = " + score;
-            DiscordRPC.discordUpdatePresence(rich);
-            ready = true;
-        }
-
-        DiscordRPC.discordShutdown();
-        w.dispose();
-    }
-
-    static class Window extends JFrame{
-        Window(){
-            super("Derp");
-            setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-            setSize(0, 0);
-            setVisible(true);
         }
     }
 
-    private static String getInput() {
-        System.out.print("> ");
-        Scanner in = new Scanner(System.in);
-        String input = in.nextLine();
-        return input.toLowerCase();
-    }
-
-    private static void initDiscord(){
+    private static void initDiscord() {
         DiscordEventHandlers handlers = new DiscordEventHandlers();
         handlers.ready = new Ready();
         DiscordRPC.discordInitialize("415885161457123338", handlers, true);
     }
 
-    private static class Ready implements ReadyCallback{
-        public void apply(){
-            System.out.println("Ready.");
-            DiscordRichPresence rich = new DiscordRichPresence();
-            rich.state = "Running Test | Private";
-            rich.details = "Score = 0";
-            DiscordRPC.discordUpdatePresence(rich);
-            ready = true;
-        }
-    }
 }

--- a/RPCTest/src/main/java/net/arikia/dev/drpctest/Ready.java
+++ b/RPCTest/src/main/java/net/arikia/dev/drpctest/Ready.java
@@ -1,0 +1,17 @@
+package net.arikia.dev.drpctest;
+
+import net.arikia.dev.drpc.DiscordRPC;
+import net.arikia.dev.drpc.DiscordRichPresence;
+import net.arikia.dev.drpc.callbacks.ReadyCallback;
+
+public class Ready implements ReadyCallback {
+
+    public void apply() {
+        System.out.println("Ready.");
+        DiscordRichPresence rich = new DiscordRichPresence();
+        rich.state = "Running Test | Private";
+        rich.details = "Score = 0";
+        DiscordRPC.discordUpdatePresence(rich);
+    }
+
+}

--- a/discord-rpc.iml
+++ b/discord-rpc.iml
@@ -14,6 +14,6 @@
     <orderEntry type="library" name="Maven: net.java.dev.jna:jna:4.5.1" level="project" />
     <orderEntry type="library" name="Maven: commons-io:commons-io:2.6" level="project" />
     <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.6" level="project" />
-    <orderEntry type="library" name="Maven: com.github.DeJayDevelopment:discord-rpc-binaries:2134741303" level="project" />
+    <orderEntry type="library" name="Maven: com.github.Vatuu:discord-rpc-binaries:3.3.0" level="project" />
   </component>
 </module>

--- a/discord-rpc.iml
+++ b/discord-rpc.iml
@@ -12,8 +12,8 @@
     <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Maven: net.java.dev.jna:jna:4.5.1" level="project" />
-    <orderEntry type="library" name="Maven: commons-io:commons-io:2.5" level="project" />
+    <orderEntry type="library" name="Maven: commons-io:commons-io:2.6" level="project" />
     <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.6" level="project" />
-    <orderEntry type="library" name="Maven: com.github.Vatuu:discord-rpc-binaries:3.2.0" level="project" />
+    <orderEntry type="library" name="Maven: com.github.DeJayDevelopment:discord-rpc-binaries:2134741303" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -4,19 +4,19 @@
 	<groupId>net.arikia.dev</groupId>
 	<artifactId>discord-rpc</artifactId>
 	<name>DiscordRPC</name>
-	<version>1.4.3</version>
+	<version>1.5.0</version>
 	<packaging>jar</packaging>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
-	<repositories>
-		<repository>
-			<id>jitpack.io</id>
-			<url>https://jitpack.io</url>
-		</repository>
-	</repositories>
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
 
 	<dependencies>
 		<dependency>
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.5</version>
+			<version>2.6</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
@@ -37,12 +37,12 @@
 			<version>2.6</version>
 			<scope>compile</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.github.Vatuu</groupId>
-			<artifactId>discord-rpc-binaries</artifactId>
-			<version>3.2.0</version>
-			<scope>compile</scope>
-		</dependency>
+        <dependency>
+            <groupId>com.github.DeJayDevelopment</groupId>
+            <artifactId>discord-rpc-binaries</artifactId>
+            <version>2134741303</version>
+            <scope>compile</scope>
+        </dependency>
 	</dependencies>
 
 	<build>
@@ -50,7 +50,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.1</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -63,7 +63,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.6.1</version>
+				<version>3.7.0</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
@@ -72,7 +72,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.2</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>unpack</id>
@@ -81,7 +81,7 @@
 							<goal>unpack-dependencies</goal>
 						</goals>
 						<configuration>
-							<includeGroupIds>com.github.Vatuu</includeGroupIds>
+							<includeGroupIds>com.github.DeJayDevelopment</includeGroupIds>
 							<includeArtifactIds>discord-rpc-binaries</includeArtifactIds>
 							<outputDirectory>${project.build.directory}/binaries-resources</outputDirectory>
 							<overWriteReleases>true</overWriteReleases>

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,9 @@
 			<scope>compile</scope>
 		</dependency>
         <dependency>
-            <groupId>com.github.DeJayDevelopment</groupId>
-            <artifactId>discord-rpc-binaries</artifactId>
-            <version>2134741303</version>
+			<groupId>com.github.Vatuu</groupId>
+			<artifactId>discord-rpc-binaries</artifactId>
+			<version>3.3.0</version>
             <scope>compile</scope>
         </dependency>
 	</dependencies>
@@ -81,7 +81,7 @@
 							<goal>unpack-dependencies</goal>
 						</goals>
 						<configuration>
-							<includeGroupIds>com.github.DeJayDevelopment</includeGroupIds>
+							<includeGroupIds>com.github.Vatuu</includeGroupIds>
 							<includeArtifactIds>discord-rpc-binaries</includeArtifactIds>
 							<outputDirectory>${project.build.directory}/binaries-resources</outputDirectory>
 							<overWriteReleases>true</overWriteReleases>

--- a/src/main/java/net/arikia/dev/drpc/DiscordRPC.java
+++ b/src/main/java/net/arikia/dev/drpc/DiscordRPC.java
@@ -21,7 +21,7 @@ public final class DiscordRPC{
     static { loadDLL(); }
 
     //DLL-Version for Update Check.
-    private static final String DLL_VERSION = "3.2.0";
+    private static final String DLL_VERSION = "3.3.0";
     private static File homeDir;
 
     /**

--- a/src/main/java/net/arikia/dev/drpc/DiscordRPC.java
+++ b/src/main/java/net/arikia/dev/drpc/DiscordRPC.java
@@ -22,6 +22,7 @@ public final class DiscordRPC{
 
     //DLL-Version for Update Check.
     private static final String DLL_VERSION = "3.2.0";
+    private static File homeDir;
 
     /**
      * Method to initialize the Discord-RPC.
@@ -124,16 +125,21 @@ public final class DiscordRPC{
         String finalPath = "";
         String tempPath = "";
 
-        if(SystemUtils.IS_OS_WINDOWS){
-            boolean is64bit = System.getProperty("sun.arch.data.model").equals("64");
-            finalPath = is64bit ? "/win-x64/discord-rpc.dll" : "win-x86/discord-rpc.dll";
-            tempPath = System.getenv("TEMP") + "/discord-rpc.jar/discord-rpc.dll";
-        }else if(SystemUtils.IS_OS_LINUX) {
-            finalPath = "/linux/discord-rpc.so";
-            tempPath = System.getenv("TMPDIR") + "/discord-rpc.jar/discord-rpc.so";
-        }else if(SystemUtils.IS_OS_MAC || SystemUtils.IS_OS_MAC_OSX){
-            finalPath = "/osx/discord-rpc.dylib";
-            tempPath = System.getenv("TMPDIR") + "/discord-rpc/discord-rpc.dylib";
+        if (homeDir == null) {
+            if (SystemUtils.IS_OS_MAC_OSX) {
+                homeDir = new File(System.getProperty("user.home") + "/Library/Application Support/");
+                finalPath = "/darwin/libdiscord-rpc.dylib";
+                tempPath = homeDir + "/discord-rpc/libdiscord-rpc.dylib";
+            } else if (SystemUtils.IS_OS_WINDOWS) {
+                homeDir = new File(System.getenv("TEMP") + "/discord-rpc");
+                boolean is64bit = System.getProperty("sun.arch.data.model").equals("64");
+                finalPath = is64bit ? "/win-x64/discord-rpc.dll" : "win-x86/discord-rpc.dll";
+                tempPath = homeDir + "/discord-rpc.jar/discord-rpc.dll";
+            } else {
+                homeDir = new File(System.getProperty("user.home"), ".discord-rpc");
+                finalPath = "/linux/libdiscord-rpc.so";
+                tempPath = homeDir + "/discord-rpc.jar/libdiscord-rpc.so";
+            }
         }
 
         File f = new File(tempPath);
@@ -141,7 +147,7 @@ public final class DiscordRPC{
         try(InputStream in = DiscordRPC.class.getResourceAsStream(finalPath); OutputStream out = FileUtils.openOutputStream(f)){
             IOUtils.copy(in, out);
             FileUtils.forceDeleteOnExit(f);
-        }catch(IOException e){
+        } catch(IOException e){
             e.printStackTrace();
         }
 
@@ -162,4 +168,6 @@ public final class DiscordRPC{
         void Discord_ClearPresence();
         void Discord_Respond(String userId, int reply);
     }
+
+
 }

--- a/src/main/java/net/arikia/dev/drpc/DiscordRPC.java
+++ b/src/main/java/net/arikia/dev/drpc/DiscordRPC.java
@@ -125,21 +125,19 @@ public final class DiscordRPC{
         String finalPath = "";
         String tempPath = "";
 
-        if (homeDir == null) {
-            if (SystemUtils.IS_OS_MAC_OSX) {
-                homeDir = new File(System.getProperty("user.home") + "/Library/Application Support/");
-                finalPath = "/darwin/libdiscord-rpc.dylib";
-                tempPath = homeDir + "/discord-rpc/libdiscord-rpc.dylib";
-            } else if (SystemUtils.IS_OS_WINDOWS) {
-                homeDir = new File(System.getenv("TEMP") + "/discord-rpc");
-                boolean is64bit = System.getProperty("sun.arch.data.model").equals("64");
-                finalPath = is64bit ? "/win-x64/discord-rpc.dll" : "win-x86/discord-rpc.dll";
-                tempPath = homeDir + "/discord-rpc.jar/discord-rpc.dll";
-            } else {
-                homeDir = new File(System.getProperty("user.home"), ".discord-rpc");
-                finalPath = "/linux/libdiscord-rpc.so";
-                tempPath = homeDir + "/discord-rpc.jar/libdiscord-rpc.so";
-            }
+        if (SystemUtils.IS_OS_MAC_OSX) {
+            homeDir = new File(System.getProperty("user.home") + "/Library/Application Support/");
+            finalPath = "/darwin/libdiscord-rpc.dylib";
+            tempPath = homeDir + "/discord-rpc/libdiscord-rpc.dylib";
+        } else if (SystemUtils.IS_OS_WINDOWS) {
+            homeDir = new File(System.getenv("TEMP") + "/discord-rpc");
+            boolean is64bit = System.getProperty("sun.arch.data.model").equals("64");
+            finalPath = is64bit ? "/win-x64/discord-rpc.dll" : "win-x86/discord-rpc.dll";
+            tempPath = homeDir + "/discord-rpc.jar/discord-rpc.dll";
+        } else {
+            homeDir = new File(System.getProperty("user.home"), ".discord-rpc");
+            finalPath = "/linux/libdiscord-rpc.so";
+            tempPath = homeDir + "/discord-rpc.jar/libdiscord-rpc.so";
         }
 
         File f = new File(tempPath);


### PR DESCRIPTION
All changes:

- Uses HTML in README.MD to right align discord-rpc logo
- Fixes typo in README.MD
- Converts the RPCTest project to a fully Maven based project
- Rewrite the RPCTest project's main file in an attempt to fix various bugs found in dev
- Moves ReadyCallback to a new class file
- Updates commons-io to 2.6
- Updates discord-rpc-binaries to 3.3.0
- Updates maven-shade-plugin to 3.1.1
- Updates maven-compiler-plugin to 3.7.0
- Rewrite OS check in discord-rpc.jar to use home based dirs instead of System Properties
- Fixes various spacing problems 
- Changes version of discord-rpc.jar project to 1.5.0